### PR TITLE
Fix action repo owner and syntax in action example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ jobs:
   set-assignees:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/assignee4label@main
+    - uses: kyanagimoto/assignee4label@main
       with:
-        github-token: %{{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         configuration-path: '.github/assignee4label.yml'
 ```


### PR DESCRIPTION
The example had two issues
- It was pointing to the wrong repo
- The expression was using the wrong preffix (`%`)