### PR TITLE
Fix: update the way we loop the async functions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,22 +21,22 @@ async function run() {
     core.debug("remove assignees.")
     const issue: JSON = JSON.parse(JSON.stringify(github.context.payload.issue));
     //core.debug(`issue: ${JSON.stringify(issue)}`)
-    issue['assignees'].forEach(element => {
+    for (const element of issue['assignees']) {
       const loginName = JSON.parse(JSON.stringify(element))['login']
       //core.debug(`loginname: ${loginName}`)
       removeAssignees(client, issueNumber, loginName);
-    });
+    };
 
-    Object.keys(configurationContent).forEach(function(key) {
+    for (const key of Object.keys(configurationContent)){
       if (github.context.payload.label.name == key) {
-        JSON.parse(JSON.stringify(configurationContent[key])).forEach(element=> {
+        for (const element of JSON.parse(JSON.stringify(configurationContent[key]))) {
           if (element == ["issue-author"]) {
             element = [issue['user']['login']]
           }
           addAssignees(client, issueNumber, element);
-        });
+        };
       }
-    });
+    };
   } catch (error) {
     core.error(error);
     core.setFailed(error.message);


### PR DESCRIPTION
Fixes #20 

**Context**
The addAssignees() and removeAssignees() functions are running at the same time even though they are not meant to. That creates inconsistency in the way labels are updated in the issues that use this repository.

**Code change**
It seems that `forEach` [doesn't work well](https://dev.classmethod.jp/articles/foreach-async-await/) with async functions so I updated the way we do the looping to a `for ... of` loop [instead](https://stackoverflow.com/questions/37576685/using-async-await-with-a-foreach-loop).